### PR TITLE
Add vehicle info page

### DIFF
--- a/__tests__/api/appointment.test.ts
+++ b/__tests__/api/appointment.test.ts
@@ -1,0 +1,41 @@
+import handler from '../../pages/api/appointment';
+import { createMocks } from 'node-mocks-http';
+
+jest.mock('../../lib/prisma', () => ({
+  prisma: {
+    appointment: {
+      findFirst: jest.fn(),
+      create: jest.fn(async ({ data }) => ({ id: 'a1' }))
+    },
+    customer: {
+      upsert: jest.fn(async () => ({ id: 'c1' }))
+    }
+  }
+}));
+
+const { prisma } = require('../../lib/prisma');
+
+describe('/api/appointment', () => {
+  it('GET missing fields', async () => {
+    const { req, res } = createMocks({ method: 'GET', query: {} });
+    await handler(req as any, res as any);
+    expect(res._getStatusCode()).toBe(400);
+  });
+
+  it('GET returns appointment', async () => {
+    prisma.appointment.findFirst.mockResolvedValue({ id: 'a1' });
+    const { req, res } = createMocks({ method: 'GET', query: { plate: 'ABC', document: '123' } });
+    await handler(req as any, res as any);
+    expect(res._getStatusCode()).toBe(200);
+  });
+
+  it('POST creates appointment', async () => {
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: { serviceId: 's1', customer: 'test', phone: '5551234', plate: 'ABC', document: '123', scheduled: '2024-01-01T10:00' }
+    });
+    await handler(req as any, res as any);
+    expect(res._getStatusCode()).toBe(200);
+    expect(prisma.appointment.create).toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/ServiceCard.test.tsx
+++ b/__tests__/components/ServiceCard.test.tsx
@@ -3,8 +3,7 @@ import { ServiceCard } from '../../components/ServiceCard';
 import { CartProvider } from '../../lib/CartContext';
 
 describe('ServiceCard', () => {
-  it('calls provided callbacks', () => {
-    const onQuote = jest.fn();
+  it('calls schedule callback', () => {
     const onSchedule = jest.fn();
     render(
       <CartProvider>
@@ -14,16 +13,12 @@ describe('ServiceCard', () => {
           icon=""
           image=""
           price={100}
-          onQuote={onQuote}
           onSchedule={onSchedule}
         />
       </CartProvider>
     );
 
-    fireEvent.click(screen.getByText('Cotizar'));
     fireEvent.click(screen.getByText('Agendar'));
-
-    expect(onQuote).toHaveBeenCalled();
     expect(onSchedule).toHaveBeenCalled();
   });
 });

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -8,6 +8,7 @@ export const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) =>
       <Link href="/maintenance">Mantenimientos</Link>
       <Link href="/history">Historial</Link>
       <Link href="/cart">Carrito</Link>
+      <Link href="/lookup">Consultar</Link>
     </nav>
     <main className="flex-1 p-4">{children}</main>
     <footer className="bg-gray-100 text-center p-4 text-sm">TecniRacer 2024</footer>

--- a/components/ServiceCard.tsx
+++ b/components/ServiceCard.tsx
@@ -9,11 +9,10 @@ interface Props {
   icon: string;
   image: string;
   price: number;
-  onQuote: () => void;
   onSchedule: () => void;
 }
 
-export const ServiceCard: React.FC<Props> = ({ id, name, icon, image, price, onQuote, onSchedule }) => {
+export const ServiceCard: React.FC<Props> = ({ id, name, icon, image, price, onSchedule }) => {
   const { items, addItem } = useCart();
   const hasCart = items.length > 0;
 
@@ -27,12 +26,9 @@ export const ServiceCard: React.FC<Props> = ({ id, name, icon, image, price, onQ
       <p className="text-sm mb-2">{`Desde $${price}`}</p>
       <div className="flex gap-2 mt-auto pb-2 flex-wrap justify-center">
         {!hasCart && (
-          <>
-            <Button onClick={onQuote}>Cotizar</Button>
-            <Button onClick={onSchedule} className="bg-green-600 hover:bg-green-700">
-              Agendar
-            </Button>
-          </>
+          <Button onClick={onSchedule} className="bg-green-600 hover:bg-green-700">
+            Agendar
+          </Button>
         )}
         <Button onClick={() => addItem({ id, name, price })} className="bg-orange-600 hover:bg-orange-700">
           Agregar

--- a/pages/cart.tsx
+++ b/pages/cart.tsx
@@ -1,8 +1,10 @@
 import { useCart } from '../lib/CartContext';
 import { Button } from '../components/Button';
+import { useRouter } from 'next/router';
 
 export default function Cart() {
   const { items, removeItem, clear } = useCart();
+  const router = useRouter();
   const total = items.reduce((sum, i) => sum + i.price, 0);
 
   if (items.length === 0) {
@@ -27,8 +29,11 @@ export default function Cart() {
       </ul>
       <p className="mt-4 font-semibold">Total: ${total}</p>
       <div className="mt-4 flex gap-2">
-        <Button className="bg-green-600 hover:bg-green-700" onClick={clear}>
-          Confirmar (demo)
+        <Button
+          className="bg-green-600 hover:bg-green-700"
+          onClick={() => router.push('/vehicle?cart=1')}
+        >
+          Pagar
         </Button>
         <Button className="bg-gray-200 text-gray-800 hover:bg-gray-300" onClick={clear}>
           Vaciar

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,40 +3,16 @@ import services from '../data/services.json';
 import { ServiceCard } from '../components/ServiceCard';
 import { Carousel } from '../components/Carousel';
 import { CategoryTabs } from '../components/CategoryTabs';
-import { QuoteModal } from '../components/QuoteModal';
-import { AppointmentModal } from '../components/AppointmentModal';
-import { useQuotes } from '../lib/QuotesContext';
+import { useRouter } from 'next/router';
 
 const categories = ['Mantenimientos', 'Diagnóstico'];
 
 export default function Home() {
   const [activeCat, setActiveCat] = useState(categories[0]);
-  const [quotePrice, setQuotePrice] = useState<number | null>(null);
-  const [quoteVisible, setQuoteVisible] = useState(false);
-  const [scheduleServiceId, setScheduleServiceId] = useState<string | null>(null);
-  const { addQuote } = useQuotes();
-
-  const quote = async (id: string) => {
-    setQuotePrice(null);
-    setQuoteVisible(true);
-    const res = await fetch('/api/quote', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ serviceId: id })
-    });
-    const data = await res.json();
-    setQuotePrice(data.price);
-    addQuote({
-      id: data.quoteId,
-      price: data.price,
-      serviceId: id,
-      createdAt: new Date().toISOString(),
-      serviceName: services.find((s) => s.id === id)?.name || id,
-    });
-  };
+  const router = useRouter();
 
   const schedule = (id: string) => {
-    setScheduleServiceId(id);
+    router.push(`/vehicle?serviceId=${id}`);
   };
 
   return (
@@ -53,20 +29,11 @@ export default function Home() {
               icon={s.icon}
               image={s.image}
               price={s.basePrice}
-              onQuote={() => quote(s.id)}
               onSchedule={() => schedule(s.id)}
             />
           </div>
         ))}
       </Carousel>
-      <QuoteModal visible={quoteVisible} price={quotePrice} onClose={() => setQuoteVisible(false)} />
-      {scheduleServiceId && (
-        <AppointmentModal
-          visible={true}
-          serviceId={scheduleServiceId}
-          onClose={() => setScheduleServiceId(null)}
-        />
-      )}
     </div>
   );
 }

--- a/pages/lookup.tsx
+++ b/pages/lookup.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import { Button } from '../components/Button';
+
+export default function Lookup() {
+  const [plate, setPlate] = useState('');
+  const [document, setDocument] = useState('');
+  const [result, setResult] = useState<any>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const search = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch(`/api/appointment?plate=${encodeURIComponent(plate)}&document=${encodeURIComponent(document)}`);
+    if (res.ok) {
+      const data = await res.json();
+      setResult(data);
+      setError(null);
+    } else {
+      setResult(null);
+      setError('No se encontró la cita');
+    }
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-semibold">Consultar Cita</h1>
+      <form onSubmit={search} className="space-y-4">
+        <input
+          type="text"
+          className="border rounded w-full p-2"
+          placeholder="Placa"
+          value={plate}
+          onChange={(e) => setPlate(e.target.value)}
+          required
+        />
+        <input
+          type="text"
+          className="border rounded w-full p-2"
+          placeholder="Cédula"
+          value={document}
+          onChange={(e) => setDocument(e.target.value)}
+          required
+        />
+        <Button type="submit" className="bg-green-600 hover:bg-green-700 w-full">
+          Buscar
+        </Button>
+      </form>
+      {error && <p className="text-red-600">{error}</p>}
+      {result && (
+        <div className="border p-4 rounded space-y-1">
+          <p className="font-medium">Servicio: {result.service.name}</p>
+          <p>Fecha: {new Date(result.scheduled).toLocaleString()}</p>
+          <p>Cliente: {result.customer}</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/pages/maintenance.tsx
+++ b/pages/maintenance.tsx
@@ -1,39 +1,13 @@
 import services from '../data/services.json';
 import { ServiceCard } from '../components/ServiceCard';
-import { QuoteModal } from '../components/QuoteModal';
-import { AppointmentModal } from '../components/AppointmentModal';
-import { useState } from 'react';
-import { useQuotes } from '../lib/QuotesContext';
+import { useRouter } from 'next/router';
 
 export default function Maintenance() {
-  const [quotePrice, setQuotePrice] = useState<number | null>(null);
-  const [quoteVisible, setQuoteVisible] = useState(false);
-  const [scheduleServiceId, setScheduleServiceId] = useState<string | null>(null);
-  const { addQuote } = useQuotes();
-
+  const router = useRouter();
   const items = services.filter((s) => s.category === 'Mantenimientos');
 
-  const quote = async (id: string) => {
-    setQuotePrice(null);
-    setQuoteVisible(true);
-    const res = await fetch('/api/quote', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ serviceId: id }),
-    });
-    const data = await res.json();
-    setQuotePrice(data.price);
-    addQuote({
-      id: data.quoteId,
-      price: data.price,
-      serviceId: id,
-      createdAt: new Date().toISOString(),
-      serviceName: items.find((s) => s.id === id)?.name || id,
-    });
-  };
-
   const schedule = (id: string) => {
-    setScheduleServiceId(id);
+    router.push(`/vehicle?serviceId=${id}`);
   };
 
   return (
@@ -48,19 +22,10 @@ export default function Maintenance() {
             icon={s.icon}
             image={s.image}
             price={s.basePrice}
-            onQuote={() => quote(s.id)}
             onSchedule={() => schedule(s.id)}
           />
         ))}
       </div>
-      <QuoteModal visible={quoteVisible} price={quotePrice} onClose={() => setQuoteVisible(false)} />
-      {scheduleServiceId && (
-        <AppointmentModal
-          visible={true}
-          serviceId={scheduleServiceId}
-          onClose={() => setScheduleServiceId(null)}
-        />
-      )}
     </div>
   );
 }

--- a/pages/vehicle.tsx
+++ b/pages/vehicle.tsx
@@ -10,7 +10,8 @@ export default function Vehicle() {
 
   const [customer, setCustomer] = useState('');
   const [phone, setPhone] = useState('');
-  const [vehicle, setVehicle] = useState('');
+  const [plate, setPlate] = useState('');
+  const [document, setDocument] = useState('');
   const [scheduled, setScheduled] = useState('');
 
   const submit = async (e: React.FormEvent) => {
@@ -25,6 +26,8 @@ export default function Vehicle() {
             serviceId: s.id,
             customer,
             phone,
+            plate,
+            document,
             scheduled
           })
         })
@@ -57,9 +60,17 @@ export default function Vehicle() {
         <input
           type="text"
           className="border rounded w-full p-2"
-          placeholder="Vehículo"
-          value={vehicle}
-          onChange={(e) => setVehicle(e.target.value)}
+          placeholder="Placa"
+          value={plate}
+          onChange={(e) => setPlate(e.target.value)}
+          required
+        />
+        <input
+          type="text"
+          className="border rounded w-full p-2"
+          placeholder="Cédula"
+          value={document}
+          onChange={(e) => setDocument(e.target.value)}
           required
         />
         <input

--- a/pages/vehicle.tsx
+++ b/pages/vehicle.tsx
@@ -1,0 +1,78 @@
+import { useRouter } from 'next/router';
+import { useCart } from '../lib/CartContext';
+import { useState } from 'react';
+import { Button } from '../components/Button';
+
+export default function Vehicle() {
+  const router = useRouter();
+  const { serviceId } = router.query;
+  const { items, clear } = useCart();
+
+  const [customer, setCustomer] = useState('');
+  const [phone, setPhone] = useState('');
+  const [vehicle, setVehicle] = useState('');
+  const [scheduled, setScheduled] = useState('');
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const targets = serviceId ? [{ id: serviceId as string }] : items;
+    await Promise.all(
+      targets.map((s) =>
+        fetch('/api/appointment', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            serviceId: s.id,
+            customer,
+            phone,
+            scheduled
+          })
+        })
+      )
+    );
+    clear();
+    router.push('/history');
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-semibold">Datos del Vehículo</h1>
+      <form onSubmit={submit} className="space-y-4">
+        <input
+          type="text"
+          className="border rounded w-full p-2"
+          placeholder="Nombre"
+          value={customer}
+          onChange={(e) => setCustomer(e.target.value)}
+          required
+        />
+        <input
+          type="tel"
+          className="border rounded w-full p-2"
+          placeholder="Teléfono"
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
+          required
+        />
+        <input
+          type="text"
+          className="border rounded w-full p-2"
+          placeholder="Vehículo"
+          value={vehicle}
+          onChange={(e) => setVehicle(e.target.value)}
+          required
+        />
+        <input
+          type="datetime-local"
+          className="border rounded w-full p-2"
+          value={scheduled}
+          onChange={(e) => setScheduled(e.target.value)}
+          required
+        />
+        <Button type="submit" className="bg-green-600 hover:bg-green-700 w-full">
+          Enviar
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,6 +41,8 @@ model Appointment {
   customerId String
   customer   String
   phone      String
+  plate      String
+  document   String
   scheduled  DateTime
   createdAt  DateTime @default(now())
   service    Service  @relation(fields: [serviceId], references: [id])


### PR DESCRIPTION
## Summary
- simplify `ServiceCard` buttons and remove quoting
- add a checkout/scheduling page for vehicle data
- update index, maintenance and cart flows to use the new page
- adjust unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f4cdc107c8322a5b540f924a9985c