### PR TITLE
Normalize appointment schema

### DIFF
--- a/__tests__/api/appointment.test.ts
+++ b/__tests__/api/appointment.test.ts
@@ -23,7 +23,17 @@ describe('/api/appointment', () => {
   });
 
   it('GET returns appointment', async () => {
-    prisma.appointment.findFirst.mockResolvedValue({ id: 'a1' });
+    prisma.appointment.findFirst.mockResolvedValue({
+      id: 'a1',
+      serviceId: 's1',
+      customerId: 'c1',
+      plate: 'ABC',
+      document: '123',
+      scheduled: new Date(),
+      createdAt: new Date(),
+      service: {},
+      customer: { name: 'Test', phone: '5551234' }
+    });
     const { req, res } = createMocks({ method: 'GET', query: { plate: 'ABC', document: '123' } });
     await handler(req as any, res as any);
     expect(res._getStatusCode()).toBe(200);

--- a/pages/api/appointment.ts
+++ b/pages/api/appointment.ts
@@ -9,10 +9,11 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
     const appointment = await prisma.appointment.findFirst({
       where: { plate, document },
-      include: { service: true }
+      include: { service: true, customer: true }
     });
     if (!appointment) return res.status(404).end();
-    return res.json(appointment);
+    const { customer, ...rest } = appointment;
+    return res.json({ ...rest, customer: customer.name, phone: customer.phone });
   }
 
   if (req.method !== 'POST') return res.status(405).end();
@@ -42,9 +43,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const appointment = await prisma.appointment.create({
     data: {
       serviceId,
-      customer,
       customerId: customerRecord.id,
-      phone,
       plate,
       document,
       scheduled: new Date(scheduled)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,12 +39,13 @@ model Appointment {
   id         String   @id @default(cuid())
   serviceId  String
   customerId String
-  customer   String
-  phone      String
   plate      String
   document   String
   scheduled  DateTime
   createdAt  DateTime @default(now())
   service    Service  @relation(fields: [serviceId], references: [id])
-  customerRef Customer @relation(fields: [customerId], references: [id])
+  customer   Customer @relation(fields: [customerId], references: [id])
+
+  @@index([customerId])
+  @@index([serviceId])
 }


### PR DESCRIPTION
## Summary
- drop duplicate customer and phone fields from Appointment model
- include customer relation in appointment API GET route
- store customerId only when creating appointments
- adjust tests for updated Appointment structure

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f5e16398c8322b802bd9c5ffddf8b