### PR TITLE
Refactor service cards

### DIFF
--- a/components/ServiceCard.tsx
+++ b/components/ServiceCard.tsx
@@ -1,54 +1,37 @@
 import Image from 'next/image';
-import { Fuel } from 'lucide-react';
+import { Droplet } from 'lucide-react';
 
 type Props = {
   name: string;
   price: number;
   image: string;
-  onQuote?: () => void;
   onBook?: () => void;
-  onAdd?: () => void;
 };
 
-export default function ServiceCard({
-  name,
-  price,
-  image,
-  onQuote,
-  onBook,
-  onAdd,
-}: Props) {
+export default function ServiceCard({ name, price, image, onBook }: Props) {
   return (
-    <div className="relative flex w-full max-w-sm flex-col overflow-hidden rounded-2xl bg-white shadow-lg">
-      <div className="relative h-44 w-full">
+    <div className="group relative w-full max-w-sm overflow-hidden rounded-2xl bg-white shadow transition-transform duration-200 hover:-translate-y-1">
+      <div className="relative aspect-[3/2] w-full bg-gray-200">
         <Image
           src={image}
           alt={name}
           fill
-          className="object-cover"
           sizes="(max-width: 768px) 100vw, 33vw"
+          className="object-cover"
         />
       </div>
 
       <div className="absolute left-1/2 top-0 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white p-4 shadow">
-        <Fuel className="h-8 w-8 text-primary" />
+        <Droplet className="h-8 w-8 text-primary" />
       </div>
 
       <div className="flex flex-col items-center gap-2 p-6 text-center">
-        <h3 className="text-xl font-semibold">{name}</h3>
-        <p className="text-lg text-slate-500">Desde ${price}</p>
+        <h3 className="text-lg font-semibold">{name}</h3>
+        <p className="text-base text-slate-500">Desde ${price}</p>
 
-        <div className="mt-4 grid w-full grid-cols-3 gap-2">
-          <button onClick={onQuote} className="btn-outline">
-            Cotizar
-          </button>
-          <button onClick={onBook} className="btn-outline">
-            Agendar
-          </button>
-          <button onClick={onAdd} className="btn-outline">
-            Agregar
-          </button>
-        </div>
+        <button onClick={onBook} className="btn-outline mt-4 w-full">
+          Agendar
+        </button>
       </div>
     </div>
   );

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import services from '../data/services.json';
 import ServiceCard from '../components/ServiceCard';
-import { Carousel } from '../components/Carousel';
 import { CategoryTabs } from '../components/CategoryTabs';
 import { useRouter } from 'next/router';
 
@@ -16,22 +15,23 @@ export default function Home() {
   };
 
   return (
-    <div className="p-4">
+    <main className="mx-auto max-w-6xl px-4 py-10">
+      <h1 className="mb-8 text-3xl font-semibold">Servicios</h1>
       <CategoryTabs categories={categories} active={activeCat} onChange={setActiveCat} />
-      <Carousel>
+
+      <div className="mt-8 grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
         {services
           .filter((s) => s.category === activeCat)
           .map((s) => (
-          <div key={s.id} className="w-60 sm:w-72">
             <ServiceCard
+              key={s.id}
               name={s.name}
-              image={s.image}
               price={s.basePrice}
+              image={s.image}
               onBook={() => schedule(s.id)}
             />
-          </div>
-        ))}
-      </Carousel>
-    </div>
+          ))}
+      </div>
+    </main>
   );
 }

--- a/pages/maintenance.tsx
+++ b/pages/maintenance.tsx
@@ -1,5 +1,5 @@
 import services from '../data/services.json';
-import { ServiceCard } from '../components/ServiceCard';
+import ServiceCard from '../components/ServiceCard';
 import { useRouter } from 'next/router';
 
 export default function Maintenance() {
@@ -13,16 +13,14 @@ export default function Maintenance() {
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-xl font-semibold">Mantenimientos</h1>
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {items.map((s) => (
           <ServiceCard
             key={s.id}
-            id={s.id}
             name={s.name}
-            icon={s.icon}
             image={s.image}
             price={s.basePrice}
-            onSchedule={() => schedule(s.id)}
+            onBook={() => schedule(s.id)}
           />
         ))}
       </div>


### PR DESCRIPTION
## Summary
- update ServiceCard component for consistent aspect ratio and single CTA
- display services in a responsive grid on index page
- update maintenance page to use new ServiceCard API

## Testing
- `npm install`
- `npm test`
- `npx tsc -p tsconfig.json --noEmit` *(fails: QuoteGetPayload missing)*

------
https://chatgpt.com/codex/tasks/task_e_684f89a935a48322b7f4d8cfa60efa89