### PR TITLE
UI tweaks and accessibility fixes

### DIFF
--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -2,14 +2,23 @@ import React from 'react';
 
 interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode;
-  variant?: 'primary';
+  variant?: 'primary' | 'secondary';
 }
 
-export const Button: React.FC<Props> = ({ children, variant, className = '', ...rest }) => {
-  const variantClass = variant === 'primary' ? 'bg-brand-red text-white hover:bg-brand-red/90' : '';
+export const Button: React.FC<Props> = ({
+  children,
+  variant = 'secondary',
+  className = '',
+  ...rest
+}) => {
+  const variantClass =
+    variant === 'primary'
+      ? 'bg-brand-red text-white hover:bg-brand-red/90'
+      : 'bg-brand-blue text-white hover:bg-brand-blue/90';
+  const disabledClass = rest.disabled ? 'cursor-not-allowed opacity-50' : '';
   return (
     <button
-      className={`px-4 py-2 rounded font-medium transition-colors disabled:opacity-50 ${variantClass} ${className}`}
+      className={`px-4 py-2 rounded font-medium transition-colors ${variantClass} ${disabledClass} ${className}`}
       {...rest}
     >
       {children}

--- a/components/EmptyState.tsx
+++ b/components/EmptyState.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const EmptyState: React.FC<{ message?: string }> = ({ message = 'No hay resultados' }) => (
+  <div className="py-8 text-center text-gray-500">{message}</div>
+);

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import React from 'react';
 
 export const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <div className="min-h-screen flex flex-col">
+  <div className="min-h-screen flex flex-col" suppressHydrationWarning>
     <nav className="bg-blue-600 text-white p-4 flex gap-4">
       <Link href="/" className="font-semibold">Inicio</Link>
       <Link href="/maintenance">Mantenimientos</Link>

--- a/components/QuoteModal.tsx
+++ b/components/QuoteModal.tsx
@@ -10,7 +10,11 @@ interface Props {
 export const QuoteModal: React.FC<Props> = ({ visible, price, onClose }) => {
   if (!visible) return null;
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center">
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center"
+      aria-modal="true"
+      role="dialog"
+    >
       <div className="bg-white p-6 rounded-xl shadow w-80">
         <h2 className="text-lg font-semibold mb-4">Cotización</h2>
         <ol className="flex justify-between mb-4 text-sm">

--- a/components/ServiceCard.tsx
+++ b/components/ServiceCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { motion } from 'framer-motion';
+import { motion } from 'framer-motion/dist/framer-motion';
+import Image from 'next/image';
 
 import { Button } from './Button';
 import { useCart } from '../lib/CartContext';
@@ -19,13 +20,16 @@ export const ServiceCard: React.FC<Props> = ({ id, name, icon, image, price, onS
 
   return (
     <motion.div
-      className="bg-white rounded-xl border border-brand-blue/10 flex flex-col items-center"
-      whileHover={{ y: -4, boxShadow: '0 10px 20px rgba(0,0,0,.15)' }}
+      className="bg-white rounded-xl border border-brand-blue/10 flex flex-col items-center hover:shadow-card transition-shadow"
+      whileHover={{ y: -4 }}
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ duration: 0.25 }}
     >
-      <div className="w-full aspect-video overflow-hidden rounded-t-xl">
-        <img src={image} alt={name} className="w-full h-full object-cover" />
+      <div className="w-full aspect-video overflow-hidden rounded-t-xl relative">
+        <Image src={image} alt={name} fill className="object-cover" />
       </div>
-      <img src={icon} alt={name} className="w-12 h-12 -mt-6 bg-white rounded-full p-2 shadow" />
+      <Image src={icon} alt={name} width={48} height={48} className="-mt-6 bg-white rounded-full p-2 shadow" />
       <h3 className="font-semibold mt-2 text-center">{name}</h3>
       <p className="text-sm mb-2">{`Desde $${price}`}</p>
       <div className="flex gap-2 mt-auto pb-2 flex-wrap justify-center">

--- a/components/ServiceGrid.tsx
+++ b/components/ServiceGrid.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ServiceCard } from './ServiceCard';
+import { EmptyState } from './EmptyState';
 
 export interface Service {
   id: string;
@@ -18,19 +19,23 @@ interface Props {
 export const ServiceGrid: React.FC<Props> = ({ title, services, onSchedule }) => (
   <div>
     {title && <h2 className="text-xl font-semibold mb-4">{title}</h2>}
-    <div className="grid grid-cols-mosaic gap-6">
-      {services.map((s) => (
-        <ServiceCard
-          key={s.id}
-          id={s.id}
-          name={s.name}
-          icon={s.icon}
-          image={s.image}
-          price={s.basePrice}
-          onSchedule={() => onSchedule(s.id)}
-        />
-      ))}
-    </div>
+    {services.length === 0 ? (
+      <EmptyState message="No hay servicios disponibles" />
+    ) : (
+      <div className="grid grid-cols-mosaic gap-6">
+        {services.map((s) => (
+          <ServiceCard
+            key={s.id}
+            id={s.id}
+            name={s.name}
+            icon={s.icon}
+            image={s.image}
+            price={s.basePrice}
+            onSchedule={() => onSchedule(s.id)}
+          />
+        ))}
+      </div>
+    )}
   </div>
 );
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,9 @@
 module.exports = {
   testEnvironment: 'jsdom',
-  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   moduleNameMapper: {
-    '\\.(css|less|scss|sass)$': 'identity-obj-proxy'
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+    '^framer-motion/dist/framer-motion$': 'framer-motion'
   },
   transform: {
     '^.+\\.(ts|tsx)$': 'babel-jest'

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,11 @@
+require('@testing-library/jest-dom');
+
+// Simplify Next.js Image in tests
+jest.mock('next/image', () => ({
+  __esModule: true,
+  default: (props) => {
+    const React = require('react');
+    // eslint-disable-next-line @next/next/no-img-element
+    return React.createElement('img', props);
+  }
+}));

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,0 @@
-import '@testing-library/jest-dom';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,10 +8,16 @@ module.exports = {
     extend: {
       colors: {
         'brand-red': '#C8102E',
+        'brand-red-light': '#f36',
         'brand-blue': '#003E7E',
+        'brand-blue-light': '#1e60aa',
+        'brand-blue-dark': '#002752'
+      },
+      boxShadow: {
+        card: '0 10px 20px rgba(0,0,0,.15)'
       },
       gridTemplateColumns: {
-        mosaic: 'repeat(auto-fill, minmax(260px,1fr))',
+        mosaic: 'repeat(auto-fill, minmax(280px,1fr))',
       },
     },
   },


### PR DESCRIPTION
## Summary
- add variant="secondary" to Button
- simplify ServiceCard structure, add entrance animation, and use Next.js Image
- show EmptyState in ServiceGrid when there are no services
- improve QuoteModal accessibility
- propagate hydration warning suppression to Layout
- tweak tailwind config for branding colors and card shadow
- adjust Jest configuration and setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fa86dcfd48322887af6cfd69ab8b4