### PR TITLE
Fix width of ServiceGrid container

### DIFF
--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -2,11 +2,16 @@ import React from 'react';
 
 interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode;
-  variant?: 'primary';
+  variant?: 'primary' | 'secondary';
 }
 
 export const Button: React.FC<Props> = ({ children, variant, className = '', ...rest }) => {
-  const variantClass = variant === 'primary' ? 'bg-brand-red text-white hover:bg-brand-red/90' : '';
+  const variantClass =
+    variant === 'primary'
+      ? 'bg-brand-red text-white hover:bg-brand-red/90'
+      : variant === 'secondary'
+        ? 'bg-brand-blue text-white hover:bg-brand-blue/90'
+        : '';
   return (
     <button
       className={`px-4 py-2 rounded font-medium transition-colors disabled:opacity-50 ${variantClass} ${className}`}

--- a/components/CategoryTabs.tsx
+++ b/components/CategoryTabs.tsx
@@ -13,7 +13,7 @@ export const CategoryTabs: React.FC<Props> = ({ categories, active, onChange }) 
         key={c}
         onClick={() => onChange(c)}
         className={`px-4 py-2 rounded-full whitespace-nowrap ${
-          c === active ? 'bg-blue-500 text-white' : 'bg-gray-200'
+          c === active ? 'bg-brand-blue text-white' : 'bg-gray-200'
         }`}
       >
         {c}

--- a/components/ServiceGrid.tsx
+++ b/components/ServiceGrid.tsx
@@ -16,9 +16,11 @@ interface Props {
 }
 
 export const ServiceGrid: React.FC<Props> = ({ title, services, onSchedule }) => (
-  <div>
-    {title && <h2 className="text-xl font-semibold mb-4">{title}</h2>}
-    <div className="grid grid-cols-mosaic gap-6">
+  <section className="space-y-8">
+    {title && (
+      <h2 className="text-2xl font-semibold text-brand-blue">{title}</h2>
+    )}
+    <div className="grid w-full grid-cols-mosaic gap-6">
       {services.map((s) => (
         <ServiceCard
           key={s.id}
@@ -31,6 +33,6 @@ export const ServiceGrid: React.FC<Props> = ({ title, services, onSchedule }) =>
         />
       ))}
     </div>
-  </div>
+  </section>
 );
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import services from '../data/services.json';
-import { ServiceCard } from '../components/ServiceCard';
-import { Carousel } from '../components/Carousel';
+import { ServiceGrid } from '../components/ServiceGrid';
 import { CategoryTabs } from '../components/CategoryTabs';
 import { useRouter } from 'next/router';
 
@@ -16,24 +15,16 @@ export default function Home() {
   };
 
   return (
-    <div className="p-4">
-      <CategoryTabs categories={categories} active={activeCat} onChange={setActiveCat} />
-      <Carousel>
-        {services
-          .filter((s) => s.category === activeCat)
-          .map((s) => (
-          <div key={s.id} className="w-60 sm:w-72">
-            <ServiceCard
-              id={s.id}
-              name={s.name}
-              icon={s.icon}
-              image={s.image}
-              price={s.basePrice}
-              onSchedule={() => schedule(s.id)}
-            />
-          </div>
-        ))}
-      </Carousel>
+    <div className="p-4 space-y-4">
+      <CategoryTabs
+        categories={categories}
+        active={activeCat}
+        onChange={setActiveCat}
+      />
+      <ServiceGrid
+        services={services.filter((s) => s.category === activeCat)}
+        onSchedule={schedule}
+      />
     </div>
   );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,7 +12,7 @@ module.exports = {
         'brand-blue': '#003E7E',
       },
       gridTemplateColumns: {
-        mosaic: 'repeat(auto-fill, minmax(200px,1fr))',
+        mosaic: 'repeat(auto-fill, minmax(180px,1fr))',
       },
     },
   },


### PR DESCRIPTION
## Summary
- ensure service mosaic grid expands to full width
- change ServiceGrid wrapper to a `<section>` with brand heading style
- use ServiceGrid in the home page instead of the horizontal carousel
- add brand-blue highlight on category tabs
- add secondary button variant and refine mosaic breakpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684fac23da6c8322b24c9dc6fd782275