### PR TITLE
Fix mosaic grid and improve components

### DIFF
--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode;
-  variant?: 'primary' | 'secondary';
+  variant?: 'primary' | 'secondary' | 'outline' | 'ghost';
 }
 
 export const Button: React.FC<Props> = ({ children, variant, className = '', ...rest }) => {
@@ -11,10 +11,14 @@ export const Button: React.FC<Props> = ({ children, variant, className = '', ...
       ? 'bg-brand-red text-white hover:bg-brand-red/90'
       : variant === 'secondary'
       ? 'bg-brand-blue text-white hover:bg-brand-blue/90'
+      : variant === 'outline'
+      ? 'border-2 border-brand-blue text-brand-blue hover:bg-brand-blue/10'
+      : variant === 'ghost'
+      ? 'text-brand-blue hover:bg-brand-blue/10'
       : '';
   return (
     <button
-      className={`px-4 py-2 rounded font-medium transition-colors disabled:opacity-50 ${variantClass} ${className}`}
+      className={`px-4 py-2 rounded font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${variantClass} ${className}`}
       {...rest}
     >
       {children}

--- a/components/CategoryTabs.tsx
+++ b/components/CategoryTabs.tsx
@@ -12,7 +12,7 @@ export const CategoryTabs: React.FC<Props> = ({ categories, active, onChange }) 
       <button
         key={c}
         onClick={() => onChange(c)}
-        className={`px-4 py-2 rounded-full whitespace-nowrap ${
+        className={`px-4 py-2 rounded-full whitespace-nowrap focus:outline-none focus:ring-2 focus:ring-brand-blue/40 ${
           c === active
             ? 'bg-brand-blue text-white'
             : 'bg-gray-200 text-brand-blue'

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -10,7 +10,7 @@ export const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) =>
       <Link href="/cart">Carrito</Link>
       <Link href="/lookup">Consultar</Link>
     </nav>
-    <main className="flex-1 p-4">{children}</main>
+    <main className="flex-1 p-4 max-w-screen-xl mx-auto">{children}</main>
     <footer className="bg-gray-100 text-center p-4 text-sm">TecniRacer 2024</footer>
   </div>
 );

--- a/components/ServiceCard.tsx
+++ b/components/ServiceCard.tsx
@@ -19,8 +19,8 @@ export const ServiceCard: React.FC<Props> = ({ id, name, icon, image, price, onS
 
   return (
     <motion.div
-      className="bg-white rounded-xl border border-brand-blue/10 flex flex-col items-center aspect-square"
-      whileHover={{ y: -4, boxShadow: '0 10px 20px rgba(0,0,0,.15)' }}
+      className="bg-white rounded-xl border border-brand-blue/10 flex flex-col items-center aspect-square hover:shadow-card"
+      whileHover={{ y: -4 }}
     >
       <div className="w-full aspect-video overflow-hidden rounded-t-xl">
         <img src={image} alt={name} className="w-full h-full object-cover" />

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,9 +10,14 @@ module.exports = {
       colors: {
         'brand-red': '#C8102E',
         'brand-blue': '#003E7E',
+        'brand-blue-light': '#2C5FB8',
+        'brand-blue-dark': '#002B58',
       },
       gridTemplateColumns: {
-        mosaic: 'repeat(auto-fill, minmax(200px,1fr))',
+        mosaic: 'repeat(auto-fill,minmax(180px,1fr))',
+      },
+      boxShadow: {
+        card: '0 10px 20px rgba(0,0,0,.15)',
       },
     },
   },


### PR DESCRIPTION
## Summary
- tune Tailwind config for mosaic grid and brand palette
- add outline and ghost variants to `Button`
- improve accessibility in `CategoryTabs`
- restrict `Layout` main content width
- use `hover:shadow-card` in `ServiceCard`

## Testing
- `npm test`
- `npx tailwindcss -i ./styles/globals.css -o /tmp/out.css`

------
https://chatgpt.com/codex/tasks/task_e_684fba06582c8322874d68c4fdbd2b72