### PR TITLE
Improve grid layout and theme colors

### DIFF
--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -8,13 +8,13 @@ interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 export const Button: React.FC<Props> = ({ children, variant, className = '', ...rest }) => {
   const variantClass =
     variant === 'primary'
-      ? 'bg-brand-red text-white hover:bg-brand-red/90'
+      ? 'bg-secondary-500 text-white hover:bg-secondary-600'
       : variant === 'secondary'
-      ? 'bg-brand-blue text-white hover:bg-brand-blue/90'
+      ? 'bg-primary-600 text-white hover:bg-primary-700'
       : variant === 'outline'
-      ? 'border-2 border-brand-blue text-brand-blue hover:bg-brand-blue/10'
+      ? 'border-2 border-primary-600 text-primary-600 hover:bg-primary-50'
       : variant === 'ghost'
-      ? 'text-brand-blue hover:bg-brand-blue/10'
+      ? 'text-primary-600 hover:bg-primary-50'
       : '';
   return (
     <button

--- a/components/CategoryTabs.tsx
+++ b/components/CategoryTabs.tsx
@@ -12,10 +12,10 @@ export const CategoryTabs: React.FC<Props> = ({ categories, active, onChange }) 
       <button
         key={c}
         onClick={() => onChange(c)}
-        className={`px-4 py-2 rounded-full whitespace-nowrap focus:outline-none focus:ring-2 focus:ring-brand-blue/40 ${
+        className={`px-4 py-2 rounded-full whitespace-nowrap focus:outline-none focus:ring-2 focus:ring-primary-400 ${
           c === active
-            ? 'bg-brand-blue text-white'
-            : 'bg-gray-200 text-brand-blue'
+            ? 'bg-primary-600 text-white'
+            : 'bg-gray-200 text-primary-600'
         }`}
       >
         {c}

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 export const Layout: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <div className="min-h-screen flex flex-col">
-    <nav className="bg-brand-red text-white p-4 flex gap-4">
+    <nav className="bg-secondary-500 text-white p-4 flex gap-4">
       <Link href="/" className="font-semibold">Inicio</Link>
       <Link href="/maintenance">Mantenimientos</Link>
       <Link href="/history">Historial</Link>

--- a/components/ServiceCard.tsx
+++ b/components/ServiceCard.tsx
@@ -19,7 +19,7 @@ export const ServiceCard: React.FC<Props> = ({ id, name, icon, image, price, onS
 
   return (
     <motion.div
-      className="bg-white rounded-xl border border-brand-blue/10 flex flex-col items-center aspect-square hover:shadow-card"
+      className="bg-white rounded-xl border border-primary-600/10 flex flex-col items-center aspect-square hover:shadow-card"
       whileHover={{ y: -4 }}
     >
       <div className="w-full aspect-video overflow-hidden rounded-t-xl">

--- a/components/ServiceGrid.tsx
+++ b/components/ServiceGrid.tsx
@@ -18,9 +18,9 @@ interface Props {
 export const ServiceGrid: React.FC<Props> = ({ title, services, onSchedule }) => (
   <section className="space-y-8">
     {title && (
-      <h2 className="text-2xl font-semibold text-brand-blue">{title}</h2>
+      <h2 className="text-2xl font-semibold text-primary-600">{title}</h2>
     )}
-    <div className="grid w-full grid-cols-mosaic gap-6">
+    <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
       {services.map((s) => (
         <ServiceCard
           key={s.id}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,10 +8,30 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        'brand-red': '#C8102E',
-        'brand-blue': '#003E7E',
-        'brand-blue-light': '#2C5FB8',
-        'brand-blue-dark': '#002B58',
+        primary: {
+          50: '#eaf3ff',
+          100: '#d6e5ff',
+          200: '#adcaff',
+          300: '#84aeff',
+          400: '#5b93ff',
+          500: '#3278ff',
+          600: '#2960cc',
+          700: '#204899',
+          800: '#183066',
+          900: '#0f1833',
+        },
+        secondary: {
+          50: '#ffeaea',
+          100: '#ffd6d6',
+          200: '#ffadad',
+          300: '#ff8484',
+          400: '#ff5b5b',
+          500: '#ff3232',
+          600: '#cc2828',
+          700: '#991e1e',
+          800: '#661414',
+          900: '#330a0a',
+        },
       },
       gridTemplateColumns: {
         mosaic: 'repeat(auto-fill,minmax(180px,1fr))',


### PR DESCRIPTION
## Summary
- extend Tailwind theme with primary and secondary color scales
- use new theme colors in layout, buttons and tabs
- make service grid responsive with Tailwind breakpoints
- update card border color

## Testing
- `npx jest --env=jsdom`

------
https://chatgpt.com/codex/tasks/task_e_684fc19956c08322b166b5eb4ceea4c5